### PR TITLE
Only access CMHW from main thread.

### DIFF
--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -729,6 +729,19 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
 
     public static final Indexable.SearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
             new BaseSearchIndexProvider() {
+                private boolean mHasTapToWake;
+                private boolean mHasSunlightEnhancement, mHasColorEnhancement;
+                private boolean mHasDisplayGamma, mHasDisplayColor;
+
+                @Override
+                public void prepare() {
+                    mHasTapToWake = isTapToWakeSupported();
+                    mHasSunlightEnhancement = isSunlightEnhancementSupported();
+                    mHasColorEnhancement = isColorEnhancementSupported();
+                    mHasDisplayGamma = DisplayGamma.isSupported();
+                    mHasDisplayColor = DisplayColor.isSupported();
+                }
+
                 @Override
                 public List<SearchIndexableResource> getXmlResourcesToIndex(Context context,
                         boolean enabled) {
@@ -761,22 +774,22 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
                             com.android.internal.R.bool.config_proximityCheckOnWake)) {
                         result.add(KEY_PROXIMITY_WAKE);
                     }
-                    if (!isTapToWakeSupported()) {
+                    if (!mHasTapToWake) {
                         result.add(KEY_TAP_TO_WAKE);
                     }
-                    if (!isSunlightEnhancementSupported()) {
+                    if (!mHasSunlightEnhancement) {
                         result.add(KEY_SUNLIGHT_ENHANCEMENT);
                     }
-                    if (!isColorEnhancementSupported()) {
+                    if (!mHasColorEnhancement) {
                         result.add(KEY_COLOR_ENHANCEMENT);
                     }
                     if (!isPostProcessingSupported(context)) {
                         result.add(KEY_SCREEN_COLOR_SETTINGS);
                     }
-                    if (!DisplayColor.isSupported()) {
+                    if (!mHasDisplayColor) {
                         result.add(KEY_DISPLAY_COLOR);
                     }
-                    if (!DisplayGamma.isSupported()) {
+                    if (!mHasDisplayGamma) {
                         result.add(KEY_DISPLAY_GAMMA);
                     }
                     if (!isAutomaticBrightnessAvailable(context.getResources())) {

--- a/src/com/android/settings/search/BaseSearchIndexProvider.java
+++ b/src/com/android/settings/search/BaseSearchIndexProvider.java
@@ -33,6 +33,10 @@ public class BaseSearchIndexProvider implements Indexable.SearchIndexProvider {
     }
 
     @Override
+    public void prepare() {
+    }
+
+    @Override
     public List<SearchIndexableResource> getXmlResourcesToIndex(Context context, boolean enabled) {
         return null;
     }

--- a/src/com/android/settings/search/Index.java
+++ b/src/com/android/settings/search/Index.java
@@ -522,6 +522,18 @@ public class Index {
         synchronized (mDataToProcess) {
             final UpdateIndexTask task = new UpdateIndexTask();
             UpdateData copy = mDataToProcess.copy();
+            for (SearchIndexableData data : copy.dataToUpdate) {
+                if (data instanceof SearchIndexableResource) {
+                    SearchIndexableResource sir = (SearchIndexableResource) data;
+                    final Class<?> clazz = sir.className != null
+                            ? getIndexableClass(sir.className) : null;
+                    final Indexable.SearchIndexProvider provider = clazz != null
+                            ? getSearchIndexProvider(clazz) : null;
+                    if (provider != null) {
+                        provider.prepare();
+                    }
+                }
+            }
             task.execute(copy);
             mDataToProcess.clear();
         }

--- a/src/com/android/settings/search/Indexable.java
+++ b/src/com/android/settings/search/Indexable.java
@@ -65,5 +65,10 @@ public interface Indexable {
          * @return a list of {@link SearchIndexableRaw} references. Can be null.
          */
         List<String> getNonIndexableKeys(Context context);
+
+        /**
+         * Prepare for indexing. Guaranteed to be called from the main thread.
+         */
+        void prepare();
     }
 }


### PR DESCRIPTION
Some CMHW classes might expect that they're created in the main thread,
e.g. if they want to use Handlers.

Change-Id: I319709a423547368b3c4f047c2efbfab4c191953