### PR TITLE
Settings: set volume wake dependency in code

### DIFF
--- a/res/xml/button_settings.xml
+++ b/res/xml/button_settings.xml
@@ -224,15 +224,13 @@
             android:key="volume_wake_screen"
             android:title="@string/button_wake_title"
             android:summary="@string/button_wake_summary"
-            android:defaultValue="false"
-            android:disableDependentsState="true" />
+            android:defaultValue="false" />
 
         <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
             android:key="volbtn_music_controls"
             android:title="@string/volbtn_music_controls_title"
             android:summary="@string/volbtn_music_controls_summary"
-            android:defaultValue="true"
-            android:dependency="volume_wake_screen" />
+            android:defaultValue="true" />
 
         <ListPreference
             android:key="volume_key_cursor_control"

--- a/src/com/android/settings/ButtonSettings.java
+++ b/src/com/android/settings/ButtonSettings.java
@@ -76,6 +76,7 @@ public class ButtonSettings extends SettingsPreferenceFragment implements
     private static final String KEY_NAVIGATION_RECENTS_LONG_PRESS = "navigation_recents_long_press";
     private static final String KEY_POWER_END_CALL = "power_end_call";
     private static final String KEY_HOME_ANSWER_CALL = "home_answer_call";
+    private static final String KEY_VOLUME_MUSIC_CONTROLS = "volbtn_music_controls";
 
     private static final String CATEGORY_POWER = "power_key";
     private static final String CATEGORY_HOME = "home_key";
@@ -120,6 +121,8 @@ public class ButtonSettings extends SettingsPreferenceFragment implements
     private ListPreference mAppSwitchPressAction;
     private ListPreference mAppSwitchLongPressAction;
     private ListPreference mVolumeKeyCursorControl;
+    private SwitchPreference mVolumeWakeScreen;
+    private SwitchPreference mVolumeMusicControls;
     private SwitchPreference mSwapVolumeButtons;
     private SwitchPreference mDisableNavigationKeys;
     private SwitchPreference mNavigationBarLeftPref;
@@ -196,6 +199,16 @@ public class ButtonSettings extends SettingsPreferenceFragment implements
         if (mNavigationPreferencesCat.getPreferenceCount() == 0) {
             // Hide navigation bar category
             prefScreen.removePreference(mNavigationPreferencesCat);
+        }
+
+        mVolumeWakeScreen = (SwitchPreference) findPreference(Settings.System.VOLUME_WAKE_SCREEN);
+        mVolumeMusicControls = (SwitchPreference) findPreference(KEY_VOLUME_MUSIC_CONTROLS);
+
+        if (mVolumeWakeScreen != null) {
+            if (mVolumeMusicControls != null) {
+                mVolumeMusicControls.setDependency(Settings.System.VOLUME_WAKE_SCREEN);
+                mVolumeWakeScreen.setDisableDependentsState(true);
+            }
         }
     }
 


### PR DESCRIPTION
It is possible for volume_wake_screen to be removed from the preference
list, but volbtn_music_controls has a hard dependency on
volume_wake_screen. Let's setup this depenency only if both exist.

Change-Id: I18b2ecc0de36779ebdea3a0d20c1971ce85549cb
Signed-off-by: Roman Birg <roman@cyngn.com>