### PR TITLE
Hide unused msim icons on setting preference(1/2)

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -413,6 +413,11 @@
     <string name="status_bar_battery_percentage_text_inside">Inside the icon</string>
     <string name="status_bar_battery_percentage_text_next">Next to the icon</string>
 
+    <!-- Status bar - MSIM tweaks-->
+    <string name="status_bar_show_unused_sims_title">Show empty SIM icons</string>
+    <string name="status_bar_show_unused_sims_title_summary_off">Hide icons of unused SIM slots</string>
+    <string name="status_bar_show_unused_sims_title_summary_on">Indicate unused SIM slots</string>
+
     <!-- Notification light dialogs -->
     <string name="edit_light_settings">Edit light settings</string>
     <string name="pulse_speed_title">Pulse length and speed</string>

--- a/res/xml/status_bar_settings.xml
+++ b/res/xml/status_bar_settings.xml
@@ -47,6 +47,13 @@
         android:entryValues="@array/status_bar_battery_percentage_values" />
 
     <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
+        android:key="status_bar_show_empty_sims"
+        android:defaultValue="true"
+        android:title="@string/status_bar_show_unused_sims_title"
+        android:summaryOn="@string/status_bar_show_unused_sims_title_summary_on"
+        android:summaryOff="@string/status_bar_show_unused_sims_title_summary_off" />
+
+    <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
         android:key="status_bar_brightness_control"
         android:title="@string/status_bar_toggle_brightness"
         android:summary="@string/status_bar_toggle_brightness_summary"

--- a/src/com/android/settings/cyanogenmod/StatusBarSettings.java
+++ b/src/com/android/settings/cyanogenmod/StatusBarSettings.java
@@ -25,6 +25,7 @@ import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.provider.SearchIndexableResource;
 import android.provider.Settings;
+import android.telephony.TelephonyManager;
 import android.text.format.DateFormat;
 import android.view.View;
 
@@ -65,7 +66,6 @@ public class StatusBarSettings extends SettingsPreferenceFragment
 
         mStatusBarClock = (ListPreference) findPreference(STATUS_BAR_CLOCK_STYLE);
         mStatusBarAmPm = (ListPreference) findPreference(STATUS_BAR_AM_PM);
-
         mStatusBarBattery = (ListPreference) findPreference(STATUS_BAR_BATTERY_STYLE);
         mStatusBarBatteryShowPercent =
                 (ListPreference) findPreference(STATUS_BAR_SHOW_BATTERY_PERCENT);
@@ -99,6 +99,10 @@ public class StatusBarSettings extends SettingsPreferenceFragment
         mStatusBarBatteryShowPercent.setSummary(mStatusBarBatteryShowPercent.getEntry());
         enableStatusBarBatteryDependents(batteryStyle);
         mStatusBarBatteryShowPercent.setOnPreferenceChangeListener(this);
+
+        if (TelephonyManager.getDefault().getPhoneCount() <= 1) {
+            removePreference(Settings.System.STATUS_BAR_MSIM_SHOW_EMPTY_ICONS);
+        }
     }
 
     @Override


### PR DESCRIPTION
Added a listPreference through which no-sim icons can be hidden or displayed
as per the user's wish

Change-Id: I9ffca4f4c394fb41d8d00ad550f06b4455b92350
Signed-off-by: Arvind Mukund <armu30@gmail.com>