### PR TITLE
Settings: Fix hiding proximity wake-up option

### DIFF
--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -203,8 +203,8 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
 
         boolean proximityCheckOnWake = getResources().getBoolean(
                 com.android.internal.R.bool.config_proximityCheckOnWake);
-        if (interfacePrefs != null && !proximityCheckOnWake) {
-            interfacePrefs.removePreference(findPreference(KEY_PROXIMITY_WAKE));
+        if (displayPrefs != null && !proximityCheckOnWake) {
+            displayPrefs.removePreference(findPreference(KEY_PROXIMITY_WAKE));
             Settings.System.putInt(getContentResolver(), Settings.System.PROXIMITY_ON_WAKE, 1);
         }
 


### PR DESCRIPTION
It's in 'Screen' category, not in 'Interface'.

Change-Id: I270ed469188526177876026fbc1fe9a5762bea0e