### PR TITLE
Themes: Allow switchbar text color to be themeable

### DIFF
--- a/res/layout/switch_bar.xml
+++ b/res/layout/switch_bar.xml
@@ -25,7 +25,7 @@
               android:layout_weight="1"
               android:layout_gravity="center_vertical"
               android:textAppearance="@style/TextAppearance.Switch"
-              android:textColor="?android:attr/textColorPrimary"
+              android:textColor="@color/switchbar_text_color"
               android:textAlignment="viewStart" />
 
     <com.android.settings.widget.ToggleSwitch android:id="@+id/switch_widget"

--- a/res/values/cm_colors.xml
+++ b/res/values/cm_colors.xml
@@ -54,4 +54,6 @@
     <!-- Installed app details -->
     <color name="security_settings_billing_desc_color">#ffffb060</color>
     <color name="qs_tile_default_background_color">@android:color/transparent</color>
+    <!-- Switch Bar Text Color -->
+    <color name="switchbar_text_color">#ffffffff</color>
 </resources>


### PR DESCRIPTION
Better exposing the color of the switch bar text so that a theme
can handle this assignment separately without having to touch
framework theme colors.

Change-Id: I81e3430e188f1ee0a22e92aea50878980f9cc61f